### PR TITLE
add getTeam() to sdk, make build cross platform

### DIFF
--- a/buildpackage.js
+++ b/buildpackage.js
@@ -15,11 +15,14 @@ const UglifyES = require("uglify-es");
     console.log("# Cleaning bin. Running shelljs rm -rf ./bin");
     shell.rm("-rf", "./bin");
 
+    // cross platform compile command
+    command = `${path.join("node_modules", ".bin", './')}tsc -p ${path.join("./")}tsconfig.json`
+
     // Compile typescript
-    console.log("# Compiling TypeScript. Executing `node_modules\\.bin\\tsc -p ./tsconfig.json`.");
+    console.log(`# Compiling TypeScript. Executing \`${command}\`.`);
 
     try {
-        execSync("node_modules\\.bin\\tsc -p ./tsconfig.json", {
+        execSync(command, {
             stdio: [0, 1, 2],
             shell: true,
             cwd: __dirname,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -49,7 +49,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -71,13 +71,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "emitter-mixin": {
@@ -92,7 +92,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "es6-object-assign": {
@@ -117,12 +117,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globby": {
@@ -131,12 +131,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.3",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -151,8 +151,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -179,7 +179,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -188,7 +188,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "junk": {
@@ -203,10 +203,10 @@
       "integrity": "sha1-hs2NawTJ8wfAWmuUGZBtA2D7E6I=",
       "dev": true,
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       }
     },
     "minimatch": {
@@ -215,7 +215,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -245,7 +245,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -284,7 +284,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "promise": {
@@ -293,7 +293,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "prr": {
@@ -308,7 +308,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.8.1"
+        "resolve": "^1.1.6"
       }
     },
     "recursive-copy": {
@@ -317,16 +317,16 @@
       "integrity": "sha512-0AkHV+QtfS/1jW01z3m2t/TRTW56Fpc+xYbsoa/bqn8BCYPwmsaNjlYmUU/dyGg9w8MmGoUWihU5W+s+qjxvBQ==",
       "dev": true,
       "requires": {
-        "del": "2.2.2",
+        "del": "^2.2.0",
         "emitter-mixin": "0.0.3",
-        "errno": "0.1.7",
-        "graceful-fs": "4.1.11",
-        "junk": "1.0.3",
-        "maximatch": "0.1.0",
-        "mkdirp": "0.5.1",
-        "pify": "2.3.0",
-        "promise": "7.3.1",
-        "slash": "1.0.0"
+        "errno": "^0.1.2",
+        "graceful-fs": "^4.1.4",
+        "junk": "^1.0.1",
+        "maximatch": "^0.1.0",
+        "mkdirp": "^0.5.1",
+        "pify": "^2.3.0",
+        "promise": "^7.0.1",
+        "slash": "^1.0.0"
       }
     },
     "resolve": {
@@ -335,7 +335,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.5"
       }
     },
     "rimraf": {
@@ -344,7 +344,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       }
     },
     "shelljs": {
@@ -353,9 +353,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.3",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "slash": {
@@ -382,8 +382,8 @@
       "integrity": "sha512-RwBX0aOeHvO8MKKUeLCArQGb9OZ6xA+EqfVxsE9wqK0saFYFVLIFvHeeCOg61C6NO6KCuSiG9OjNjCA+OB4nzg==",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
-        "source-map": "0.6.1"
+        "commander": "~2.11.0",
+        "source-map": "~0.6.1"
       }
     },
     "wrappy": {

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -110,6 +110,22 @@ export interface IHostContext {
 }
 
 /**
+ * Information about the current DevOps teamz
+ */
+export interface ITeamContext {
+
+    /**
+     * Unique GUID for this team
+     */
+    id: string;
+
+    /**
+     * Name of team
+     */
+    name: string;
+}
+
+/**
  * Identifier for the current extension
  */
 export interface IExtensionContext {
@@ -152,6 +168,11 @@ interface IExtensionHandshakeResult {
     },
     initialConfig?: { [key: string]: any };
     themeData?: { [ key: string]: string };
+    pageContext?: {
+        webContext?: {
+            team?: ITeamContext;
+        }
+    }
 }
 
 const hostControlId = "DevOps.HostControl";
@@ -163,6 +184,7 @@ let initialConfiguration: { [key: string]: any } | undefined;
 let initialContributionId: string | undefined;
 let userContext: IUserContext | undefined;
 let hostContext: IHostContext | undefined;
+let teamContext: ITeamContext | undefined;
 let themeElement: HTMLStyleElement;
 
 let resolveReady: () => void;
@@ -212,6 +234,7 @@ export function init(options?: IExtensionInitOptions): Promise<void> {
             extensionContext = context.extension;
             userContext = context.user;
             hostContext = context.host;
+            teamContext = handshakeData.pageContext && handshakeData.pageContext && handshakeData.pageContext.webContext && handshakeData.pageContext.webContext.team;
 
             if (handshakeData.themeData) {
                 applyTheme(handshakeData.themeData);
@@ -292,6 +315,17 @@ export function getHost(): IHostContext {
     }
     return hostContext;
 }
+
+/**
+* Gets information about the team that the page is targeting
+*/
+export function getTeam(): ITeamContext {
+    if (!teamContext) {
+        throw new Error(getWaitForReadyError("getTeam"));
+    }
+    return teamContext;
+}
+
 
 /**
 * Get the context about the extension that owns the content that is being hosted


### PR DESCRIPTION
I am developing a widget and I need to get the team context for the current dashboard. This was possible with the old VSS sdk but not with the new. I saw how the old VSS sdk was doing it and added it here in a similar manner. Also, I am on linux and the hardcoded path in the build script failed, so I made it crossplatform.