### PR TITLE
Removing conditional operators

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -282,8 +282,8 @@ export function init(options?: IExtensionInitOptions): Promise<void> {
 
         parentChannel.invokeRemoteMethod<IExtensionHandshakeResult>("initialHandshake", hostControlId, [initOptions]).then((handshakeData) => {
             hostPageContext = handshakeData.pageContext;
-            webContext = hostPageContext.webContext;
-            teamContext = webContext.team;
+            webContext = handshakeData ? hostPageContext.webContext : undefined;
+            teamContext = webContext ? webContext.team : undefined;
 
             initialConfiguration = handshakeData.initialConfig || {};
             initialContributionId = handshakeData.contributionId;

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -281,9 +281,9 @@ export function init(options?: IExtensionInitOptions): Promise<void> {
         const initOptions = { ...options, sdkVersion };
 
         parentChannel.invokeRemoteMethod<IExtensionHandshakeResult>("initialHandshake", hostControlId, [initOptions]).then((handshakeData) => {
-            hostPageContext = handshakeData?.pageContext;
-            webContext = hostPageContext?.webContext;
-            teamContext = webContext?.team;
+            hostPageContext = handshakeData.pageContext;
+            webContext = hostPageContext.webContext;
+            teamContext = webContext.team;
 
             initialConfiguration = handshakeData.initialConfig || {};
             initialContributionId = handshakeData.contributionId;


### PR DESCRIPTION
Instead of doing a typescript update and fixing other build errors with the update, removing the conditional operators instead. They have been defined like this at the start:

`let teamContext: ITeamContext | undefined;`
`let webContext: IWebContext | undefined;;`
`let hostPageContext: IPageContext | undefined;`

And there's a null check, example:
```
export function getPageContext(): IPageContext {
    if (!hostPageContext) {
        throw new Error(getWaitForReadyError("getPageContext"));
    }
    return hostPageContext;
}
```