### PR TITLE
Fixing Page Context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-devops-extension-sdk",
-  "version": "2.0.11",
+  "version": "3.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-devops-extension-sdk",
-      "version": "2.0.11",
+      "version": "3.1.3",
       "license": "MIT",
       "dependencies": {
         "es6-object-assign": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-devops-extension-sdk",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Azure DevOps web extension JavaScript library.",
   "repository": {
     "type": "git",

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -217,10 +217,10 @@ interface IExtensionHandshakeOptions extends IExtensionInitOptions {
 }
 
 interface IExtensionHandshakeResult {
-    pageContext: IPageContext;
     contributionId: string;
     context: {
         extension: IExtensionContext,
+        pageContext: IPageContext,
         user: IUserContext,
         host: IHostContext
     },
@@ -281,14 +281,14 @@ export function init(options?: IExtensionInitOptions): Promise<void> {
         const initOptions = { ...options, sdkVersion };
 
         parentChannel.invokeRemoteMethod<IExtensionHandshakeResult>("initialHandshake", hostControlId, [initOptions]).then((handshakeData) => {
-            hostPageContext = handshakeData.pageContext;
+            const context = handshakeData.context;
+            hostPageContext = context.pageContext;
             webContext = hostPageContext ? hostPageContext.webContext : undefined;
             teamContext = webContext ? webContext.team : undefined;
 
             initialConfiguration = handshakeData.initialConfig || {};
             initialContributionId = handshakeData.contributionId;
 
-            const context = handshakeData.context;
             extensionContext = context.extension;
             userContext = context.user;
             hostContext = context.host;


### PR DESCRIPTION
`pageContext` returned from extension handshake result is within the `context` object. In the SDK, it was outside the `context` object. Putting it back properly.

Issues addressed:

- https://github.com/microsoft/azure-devops-extension-sdk/issues/81