### PR TITLE
Fix package tar

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,7 @@
 npm-debug.log
+
+rollup.config.js
+buildpackage.js
+tsconfig*.json
+
+src

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-devops-extension-sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-devops-extension-sdk",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.3",
@@ -18,8 +18,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,16 @@
 {
   "name": "azure-devops-extension-sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Azure DevOps web extension JavaScript library.",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/azure-devops-extension-sdk.git"
   },
   "engines": {
-    "node": ">=18.0.0",
-    "npm": ">=10.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
-    "build": "rollup -c rollup.config.js"
+    "build": "rollup -c rollup.config.js --bundleConfigAsCjs"
   },
   "keywords": [
     "extensions",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
   "homepage": "https://docs.microsoft.com/en-us/azure/devops/integrate",
   "main": "SDK.js",
   "types": "SDK.d.ts",
-  "files": [
-    "bin/**/*"
-  ],
+  "exports": {
+    "import": "./esm/SDK.min.js",
+    "require": "./SDK.min.js"
+  },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.3",
     "@rollup/plugin-typescript": "^11.1.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "azure-devops-extension-sdk",
   "version": "4.0.0",
   "description": "Azure DevOps web extension JavaScript library.",
-  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/azure-devops-extension-sdk.git"
@@ -26,10 +25,10 @@
   },
   "homepage": "https://docs.microsoft.com/en-us/azure/devops/integrate",
   "main": "SDK.js",
-  "types": "SDK.d.ts",
   "exports": {
+    "types": "SDK.d.ts",
     "import": "./esm/SDK.min.js",
-    "require": "./SDK.min.js"
+    "require": "SDK.min.js"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.3",


### PR DESCRIPTION
Everything gets generated correctly inside the bin folder (content used for testing) but during the `npm pack`, expected Tarball contents are missing. After the fix:
```
npm notice === Tarball Contents ===
npm notice 1.2kB  LICENSE
npm notice 2.5kB  README.md
npm notice 7.8kB  SDK.d.ts
npm notice 11.3kB SDK.js
npm notice 21.9kB SDK.js.map
npm notice 11.1kB SDK.min.js
npm notice 2.8kB  SECURITY.md
npm notice 7.5kB  XDM.d.ts
npm notice 22.8kB XDM.js
npm notice 40.7kB XDM.js.map
npm notice 7.5kB  XDM.min.js
npm notice 7.8kB  esm/SDK.d.ts
npm notice 8.9kB  esm/SDK.js
npm notice 21.7kB esm/SDK.js.map
npm notice 8.5kB  esm/SDK.min.js
npm notice 7.5kB  esm/XDM.d.ts
npm notice 18.8kB esm/XDM.js
npm notice 39.3kB esm/XDM.js.map
npm notice 5.4kB  esm/XDM.min.js
npm notice 1.1kB  package.json
```

Also, modified the `package.json` to specify a set of subpaths for different module types:

- AMD: `"require": "SDK.min.js"`
- ES: `"import": "./esm/SDK.min.js"`

Also, the `main` property and the `exports` property are not mutually exclusive and can be used together. The `main` property specifies the main entry point for the module, while the `exports` property specifies additional subpaths that can be imported by other modules.
