### PR TITLE
Expose packaged XDM files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,16 @@
   "homepage": "https://docs.microsoft.com/en-us/azure/devops/integrate",
   "main": "SDK.js",
   "exports": {
-    "types": "./SDK.d.ts",
-    "import": "./esm/SDK.min.js",
-    "require": "./SDK.min.js"
+    ".": {
+      "types": "./SDK.d.ts",
+      "import": "./esm/SDK.min.js",
+      "require": "./SDK.min.js"
+    },
+    "./XDM": {
+      "types": "./XDM.d.ts",
+      "import": "./esm/XDM.min.js",
+      "require": "./XDM.min.js"
+    }
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.3",


### PR DESCRIPTION
At the moment the XDM files are packaged but not included in the manifest. I'd like to be able to import the `channelManager` that was previously exposed by the package as I need to bridge the gap between an iframe my extension loads and the parent channel.

Here's the code for my use case:

```
/**
 * Bridge XDM channel of child window (iframe) to host/parent window's channel.
 * This allows the loaded iframe to access the DevOps SDK as if it was loaded directly (with some caveats).
 */
function createChannelBridge(childWindow: Window) {
    const parentChannel = channelManager.addChannel(window.parent)
    const childChannel = channelManager.addChannel(
        childWindow,
        childWindow.origin
    )

    const childRegister = childChannel.getObjectRegistry()

    childRegister.register(
        'DevOps.HostControl',
        parentChannel.getRemoteObjectProxy('DevOps.HostControl')
    )

    childRegister.register('DevOps.ServiceManager', {
        getService,
    })
}
```

Ideally you would also export the `hostControlId` and `serviceManagerId` constants from the SDK file.