### PR TITLE
Add forceRefresh parameter to getAccessToken() for near-expiry token recovery

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -482,9 +482,11 @@ export function unregister(instanceId: string): void {
 
 /**
 * Fetch an access token which will allow calls to be made to other DevOps services
+*
+* @param forceRefresh - If true, requests a new token from the host rather than returning a potentially cached token.
 */
-export async function getAccessToken(): Promise<string> {
-    return parentChannel.invokeRemoteMethod<{ token: string }>("getAccessToken", hostControlId).then((tokenObj) => { return tokenObj.token; });
+export async function getAccessToken(forceRefresh?: boolean): Promise<string> {
+    return parentChannel.invokeRemoteMethod<{ token: string }>("getAccessToken", hostControlId, [forceRefresh]).then((tokenObj) => { return tokenObj.token; });
 }
 
 /**


### PR DESCRIPTION
## Problem

`SDK.getAccessToken()` has no way to request a fresh token from the host. The `IAuthorizationTokenProvider` interface in `azure-devops-extension-api` already defines `forceRefresh?: boolean` on `getAuthorizationHeader()`, but `getAccessToken()` never accepted or forwarded this parameter.

## Fix

Add an optional `forceRefresh` parameter to `getAccessToken()` and forward it to the host via XDM:

```typescript
// Before
export async function getAccessToken(): Promise<string> {
    return parentChannel.invokeRemoteMethod<{ token: string }>("getAccessToken", hostControlId)
        .then((tokenObj) => { return tokenObj.token; });
}

// After
export async function getAccessToken(forceRefresh?: boolean): Promise<string> {
    return parentChannel.invokeRemoteMethod<{ token: string }>("getAccessToken", hostControlId, [forceRefresh])
        .then((tokenObj) => { return tokenObj.token; });
}
```

This is a backwards-compatible change — existing callers with no arguments are unaffected. The host-side `DevOps.HostControl` handler would also need to honor the parameter for the full flow to work.

## Companion PR

The `azure-devops-extension-api` also has two bugs (broken 401 retry + default auth provider ignoring `forceRefresh`): https://github.com/microsoft/azure-devops-extension-api/pull/187

## Impact

Every ADO web extension using `SDK.getAccessToken()` or `getClient()` is affected during long-running sessions when tokens approach expiry.