### PR TITLE
Add Nested App Authentication (NAA) bridge for MSAL v5 extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Extensions that need to authenticate with Microsoft Entra ID can use the NAA bri
 
 ```typescript
 import * as SDK from "azure-devops-extension-sdk";
-import { createNestablePublicClientApplication } from "@azure/msal-browser";
+import { createNestablePublicClientApplication, InteractionRequiredAuthError } from "@azure/msal-browser";
 
 await SDK.init();
 await SDK.enableNestedAppAuth();
@@ -99,14 +99,20 @@ const pca = await createNestablePublicClientApplication({
     auth: { clientId: "your-entra-client-id" },
 });
 
+// The NAA bridge provides SSO hints, so acquireTokenSilent will succeed
+// when the user has already authenticated in the host frame.
 try {
     const result = await pca.acquireTokenSilent({
         scopes: ["https://graph.microsoft.com/.default"],
     });
-} catch {
-    const result = await pca.acquireTokenPopup({
-        scopes: ["https://graph.microsoft.com/.default"],
-    });
+} catch (err) {
+    if (err instanceof InteractionRequiredAuthError) {
+        const result = await pca.acquireTokenPopup({
+            scopes: ["https://graph.microsoft.com/.default"],
+        });
+    } else {
+        throw err;
+    }
 }
 ```
 
@@ -114,11 +120,13 @@ try {
 
 ### Cleanup
 
-Call `disableNestedAppAuth()` when your extension no longer needs NAA (e.g., during teardown). This removes the `window.nestedAppAuthBridge` object. Any in-flight MSAL operations may fail after this call.
+Call `disableNestedAppAuth()` when your extension no longer needs NAA (e.g., during teardown or in tests). After this call, the bridge remains as a stub that returns a clear `BridgeDisabled` error for any subsequent MSAL token requests — no popup will open and no `interaction_in_progress` lock will occur.
 
 ```typescript
 SDK.disableNestedAppAuth();
 ```
+
+To re-enable, call `enableNestedAppAuth()` again.
 
 
 ## Code of Conduct

--- a/README.md
+++ b/README.md
@@ -76,6 +76,42 @@ SDK.init();
 ## API
 A full API reference of can be found [here](https://docs.microsoft.com/en-us/javascript/api/azure-devops-extension-sdk/).
 
+## Nested App Authentication (NAA)
+
+Extensions that need to authenticate with Microsoft Entra ID can use the NAA bridge to acquire tokens via MSAL.js v5+. The bridge lets your extension use `createNestablePublicClientApplication` from `@azure/msal-browser` — the ADO host frame handles the actual authentication flow on your behalf, avoiding cross-origin iframe limitations.
+
+### Prerequisites
+
+1. Register a **SPA** app in the [Azure Portal](https://portal.azure.com)
+2. Add the redirect URI: `https://dev.azure.com/_public/_MsalPopup`
+3. Configure API permissions for the scopes you need
+
+### Usage
+
+```typescript
+import * as SDK from "azure-devops-extension-sdk";
+import { createNestablePublicClientApplication } from "@azure/msal-browser";
+
+await SDK.init();
+await SDK.enableNestedAppAuth();
+
+const pca = await createNestablePublicClientApplication({
+    auth: { clientId: "your-entra-client-id" },
+});
+
+try {
+    const result = await pca.acquireTokenSilent({
+        scopes: ["https://graph.microsoft.com/.default"],
+    });
+} catch {
+    const result = await pca.acquireTokenPopup({
+        scopes: ["https://graph.microsoft.com/.default"],
+    });
+}
+```
+
+> **Note:** Call `enableNestedAppAuth()` *before* `createNestablePublicClientApplication()`. Do not set `redirectUri` in your MSAL config — the bridge provides it automatically. `enableNestedAppAuth()` will throw if the host does not support NAA.
+
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ try {
 
 > **Note:** Call `enableNestedAppAuth()` *before* `createNestablePublicClientApplication()`. Do not set `redirectUri` in your MSAL config — the bridge provides it automatically. `enableNestedAppAuth()` will throw if the host does not support NAA.
 
+### Consent
+
+On first use, `acquireTokenSilent` will fail with `consent_required` because the user hasn't consented to your app yet. The `InteractionRequiredAuthError` catch block handles this automatically by opening `acquireTokenPopup`, which shows the Entra consent prompt.
+
+After consent, subsequent `acquireTokenSilent` calls succeed without interaction.
+
+To proactively trigger consent (e.g., on a "Connect" button), use `prompt: "consent"`:
+
+```typescript
+await pca.acquireTokenPopup({
+    scopes: ["https://graph.microsoft.com/.default"],
+    prompt: "consent"
+});
+```
+
+If your app requires admin-level permissions, a tenant admin must grant consent in the Azure Portal (App Registration → API Permissions → "Grant admin consent").
+
 ### Cleanup
 
 Call `disableNestedAppAuth()` when your extension no longer needs NAA (e.g., during teardown or in tests). After this call, the bridge remains as a stub that returns a clear `BridgeDisabled` error for any subsequent MSAL token requests — no popup will open and no `interaction_in_progress` lock will occur.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A full API reference of can be found [here](https://docs.microsoft.com/en-us/jav
 
 ## Nested App Authentication (NAA)
 
-Extensions that need to authenticate with Microsoft Entra ID can use the NAA bridge to acquire tokens via MSAL.js v5+. The bridge lets your extension use `createNestablePublicClientApplication` from `@azure/msal-browser` — the ADO host frame handles the actual authentication flow on your behalf, avoiding cross-origin iframe limitations.
+Extensions that need to authenticate with Microsoft Entra ID can use the NAA bridge to acquire tokens via MSAL.js v5+. The bridge lets your extension use `createNestablePublicClientApplication` from `@azure/msal-browser` — the Azure DevOps host frame handles the actual authentication flow on your behalf, avoiding cross-origin iframe limitations.
 
 ### Prerequisites
 
@@ -111,6 +111,14 @@ try {
 ```
 
 > **Note:** Call `enableNestedAppAuth()` *before* `createNestablePublicClientApplication()`. Do not set `redirectUri` in your MSAL config — the bridge provides it automatically. `enableNestedAppAuth()` will throw if the host does not support NAA.
+
+### Cleanup
+
+Call `disableNestedAppAuth()` when your extension no longer needs NAA (e.g., during teardown). This removes the `window.nestedAppAuthBridge` object. Any in-flight MSAL operations may fail after this call.
+
+```typescript
+SDK.disableNestedAppAuth();
+```
 
 
 ## Code of Conduct

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-devops-extension-sdk",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "Azure DevOps web extension JavaScript library.",
   "repository": {
     "type": "git",

--- a/src/NestedAppAuthBridge.ts
+++ b/src/NestedAppAuthBridge.ts
@@ -34,33 +34,39 @@ const nestedAppAuthHostId = "DevOps.NestedAppAuth";
  * @param parentChannel - The XDM channel to the host frame
  */
 export async function initializeNestedAppAuthBridge(parentChannel: IXDMChannel): Promise<void> {
-    const hostProxy = await parentChannel.getRemoteObjectProxy<INestedAppAuthHost>(nestedAppAuthHostId);
-    if (!hostProxy || typeof hostProxy.processRequest !== "function") {
+    // Verify the host exposes the NAA endpoint by calling processRequest with
+    // a ping. We use invokeRemoteMethod directly instead of getRemoteObjectProxy
+    // because the host-side XDM serializer does not proxy functions.
+    try {
+        await parentChannel.invokeRemoteMethod<string>("processRequest", nestedAppAuthHostId, [
+            JSON.stringify({ messageType: "NestedAppAuthRequest", method: "Ping", requestId: "naa-init-ping" })
+        ]);
+    } catch (err: any) {
         throw new Error(
             "Nested App Authentication is not available. " +
-            "Ensure the extension declares 'entraClientId' in its manifest " +
-            "and the host has NAA support enabled."
+            "Ensure the host has NAA support enabled. " +
+            `Details: ${err?.message || err}`
         );
     }
 
     const listeners: MessageListener[] = [];
 
-        (window as any).nestedAppAuthBridge = {
-            addEventListener(type: string, listener: MessageListener): void {
-                if (type === "message") {
-                    listeners.push(listener);
+    (window as any).nestedAppAuthBridge = {
+        addEventListener(type: string, listener: MessageListener): void {
+            if (type === "message") {
+                listeners.push(listener);
+            }
+        },
+        removeEventListener(type: string, listener: MessageListener): void {
+            if (type === "message") {
+                const index = listeners.indexOf(listener);
+                if (index >= 0) {
+                    listeners.splice(index, 1);
                 }
-            },
-            removeEventListener(type: string, listener: MessageListener): void {
-                if (type === "message") {
-                    const index = listeners.indexOf(listener);
-                    if (index >= 0) {
-                        listeners.splice(index, 1);
-                    }
-                }
-            },
-            postMessage(requestJson: string): void {
-                hostProxy.processRequest(requestJson).then(
+            }
+        },
+        postMessage(requestJson: string): void {
+            parentChannel.invokeRemoteMethod<string>("processRequest", nestedAppAuthHostId, [requestJson]).then(
                     (responseJson: string) => {
                         for (const listener of listeners) {
                             try {

--- a/src/NestedAppAuthBridge.ts
+++ b/src/NestedAppAuthBridge.ts
@@ -107,9 +107,68 @@ export async function initializeNestedAppAuthBridge(parentChannel: IXDMChannel):
 }
 
 /**
- * Tears down the NAA bridge by removing `window.nestedAppAuthBridge`.
- * Call this when the extension no longer needs NAA, or during cleanup in tests.
+ * Tears down the NAA bridge by replacing `window.nestedAppAuthBridge` with a
+ * poisoned stub whose methods throw clear errors. This ensures that:
+ * - Existing MSAL PCA instances get an explicit error on their next token call
+ *   (MSAL reads `window.nestedAppAuthBridge.postMessage` on every request).
+ * - New `createNestablePublicClientApplication` calls fail during bridge init
+ *   instead of silently falling back to the standard (broken) popup flow.
  */
 export function teardownNestedAppAuthBridge(): void {
-    delete (window as any).nestedAppAuthBridge;
+    const listeners: Array<(response: string | { data: string }) => void> = [];
+
+    (window as any).nestedAppAuthBridge = {
+        postMessage(requestJson: string): void {
+            // Respond asynchronously through the registered listener so MSAL's
+            // BridgeProxy promise resolves/rejects cleanly.
+            try {
+                const request = JSON.parse(requestJson);
+                let response: object;
+
+                if (request.method === "GetInitContext") {
+                    // Let init succeed so MSAL creates a NestedAppAuth PCA
+                    // instead of falling back to the standard (broken) popup flow.
+                    response = {
+                        messageType: "NestedAppAuthResponse",
+                        requestId: request.requestId,
+                        success: true,
+                        initContext: {
+                            sdkName: "azure-devops-extension-sdk",
+                            sdkVersion: "disabled"
+                        }
+                    };
+                } else {
+                    // All actual token requests get a clear error.
+                    response = {
+                        messageType: "NestedAppAuthResponse",
+                        requestId: request.requestId,
+                        success: false,
+                        error: {
+                            status: "Disabled",
+                            code: "BridgeDisabled",
+                            description: "Nested App Authentication bridge has been disabled. Call enableNestedAppAuth() to re-enable."
+                        }
+                    };
+                }
+
+                const responseJson = JSON.stringify(response);
+                setTimeout(() => {
+                    for (const listener of listeners) {
+                        try { listener(responseJson); } catch { /* ignore */ }
+                    }
+                }, 0);
+            } catch {
+                // If we can't parse the request, nothing we can do
+            }
+        },
+        addEventListener(_type: string, listener: (response: string | { data: string }) => void): void {
+            listeners.push(listener);
+        },
+        removeEventListener(_type: string, listener: (response: string | { data: string }) => void): void {
+            const index = listeners.indexOf(listener);
+            if (index >= 0) {
+                listeners.splice(index, 1);
+            }
+        }
+    };
 }

--- a/src/NestedAppAuthBridge.ts
+++ b/src/NestedAppAuthBridge.ts
@@ -34,13 +34,16 @@ const nestedAppAuthHostId = "DevOps.NestedAppAuth";
  * @param parentChannel - The XDM channel to the host frame
  */
 export async function initializeNestedAppAuthBridge(parentChannel: IXDMChannel): Promise<void> {
-    try {
-        const hostProxy = await parentChannel.getRemoteObjectProxy<INestedAppAuthHost>(nestedAppAuthHostId);
-        if (!hostProxy || typeof hostProxy.processRequest !== "function") {
-            return;
-        }
+    const hostProxy = await parentChannel.getRemoteObjectProxy<INestedAppAuthHost>(nestedAppAuthHostId);
+    if (!hostProxy || typeof hostProxy.processRequest !== "function") {
+        throw new Error(
+            "Nested App Authentication is not available. " +
+            "Ensure the extension declares 'entraClientId' in its manifest " +
+            "and the host has NAA support enabled."
+        );
+    }
 
-        const listeners: MessageListener[] = [];
+    const listeners: MessageListener[] = [];
 
         (window as any).nestedAppAuthBridge = {
             addEventListener(type: string, listener: MessageListener): void {
@@ -96,7 +99,4 @@ export async function initializeNestedAppAuthBridge(parentChannel: IXDMChannel):
                 );
             }
         };
-    } catch {
-        // Host does not support NAA — silently skip
-    }
 }

--- a/src/NestedAppAuthBridge.ts
+++ b/src/NestedAppAuthBridge.ts
@@ -50,7 +50,10 @@ export async function initializeNestedAppAuthBridge(parentChannel: IXDMChannel):
 
     const listeners: MessageListener[] = [];
 
-    (window as any).nestedAppAuthBridge = {
+    const bridge: any = {
+        // Store listeners array as a property so teardownNestedAppAuthBridge
+        // can dispatch poisoned responses through the same listeners.
+        _naaListeners: listeners,
         addEventListener(type: string, listener: MessageListener): void {
             if (type === "message") {
                 listeners.push(listener);
@@ -104,71 +107,75 @@ export async function initializeNestedAppAuthBridge(parentChannel: IXDMChannel):
                 );
             }
         };
+
+    (window as any).nestedAppAuthBridge = bridge;
 }
 
 /**
- * Tears down the NAA bridge by replacing `window.nestedAppAuthBridge` with a
- * poisoned stub whose methods throw clear errors. This ensures that:
- * - Existing MSAL PCA instances get an explicit error on their next token call
- *   (MSAL reads `window.nestedAppAuthBridge.postMessage` on every request).
- * - New `createNestablePublicClientApplication` calls fail during bridge init
- *   instead of silently falling back to the standard (broken) popup flow.
+ * Tears down the NAA bridge by replacing the `postMessage` function on the
+ * existing `window.nestedAppAuthBridge` with a poisoned version. We mutate
+ * in-place (rather than replacing the whole object) because existing MSAL PCA
+ * instances have already registered their listener via `addEventListener` on
+ * this object — replacing the object would orphan those listeners and cause
+ * MSAL to hang waiting for a response that never arrives.
  */
 export function teardownNestedAppAuthBridge(): void {
-    const listeners: Array<(response: string | { data: string }) => void> = [];
+    const bridge = (window as any).nestedAppAuthBridge;
+    if (!bridge) {
+        return;
+    }
 
-    (window as any).nestedAppAuthBridge = {
-        postMessage(requestJson: string): void {
-            // Respond asynchronously through the registered listener so MSAL's
-            // BridgeProxy promise resolves/rejects cleanly.
-            try {
-                const request = JSON.parse(requestJson);
-                let response: object;
+    // Replace postMessage with a poisoned version that responds with errors.
+    // We keep addEventListener/removeEventListener intact so MSAL's existing
+    // listeners remain registered on the same _naaListeners array.
+    bridge.postMessage = function (requestJson: string): void {
+        try {
+            const request = JSON.parse(requestJson);
+            let response: object;
 
-                if (request.method === "GetInitContext") {
-                    // Let init succeed so MSAL creates a NestedAppAuth PCA
-                    // instead of falling back to the standard (broken) popup flow.
-                    response = {
-                        messageType: "NestedAppAuthResponse",
-                        requestId: request.requestId,
-                        success: true,
-                        initContext: {
-                            sdkName: "azure-devops-extension-sdk",
-                            sdkVersion: "disabled"
-                        }
-                    };
-                } else {
-                    // All actual token requests get a clear error.
-                    response = {
-                        messageType: "NestedAppAuthResponse",
-                        requestId: request.requestId,
-                        success: false,
-                        error: {
-                            status: "Disabled",
-                            code: "BridgeDisabled",
-                            description: "Nested App Authentication bridge has been disabled. Call enableNestedAppAuth() to re-enable."
-                        }
-                    };
-                }
-
-                const responseJson = JSON.stringify(response);
-                setTimeout(() => {
-                    for (const listener of listeners) {
-                        try { listener(responseJson); } catch { /* ignore */ }
+            if (request.method === "GetInitContext") {
+                // Let init succeed so MSAL creates a NestedAppAuth PCA
+                // instead of falling back to the standard (broken) popup flow.
+                response = {
+                    messageType: "NestedAppAuthResponse",
+                    requestId: request.requestId,
+                    success: true,
+                    initContext: {
+                        sdkName: "azure-devops-extension-sdk",
+                        sdkVersion: "disabled"
                     }
-                }, 0);
-            } catch {
-                // If we can't parse the request, nothing we can do
+                };
+            } else {
+                // All actual token requests get a clear error.
+                response = {
+                    messageType: "NestedAppAuthResponse",
+                    requestId: request.requestId,
+                    success: false,
+                    error: {
+                        status: "Disabled",
+                        code: "BridgeDisabled",
+                        description: "Nested App Authentication bridge has been disabled. Call enableNestedAppAuth() to re-enable."
+                    }
+                };
             }
-        },
-        addEventListener(_type: string, listener: (response: string | { data: string }) => void): void {
-            listeners.push(listener);
-        },
-        removeEventListener(_type: string, listener: (response: string | { data: string }) => void): void {
-            const index = listeners.indexOf(listener);
-            if (index >= 0) {
-                listeners.splice(index, 1);
-            }
+
+            const responseJson = JSON.stringify(response);
+            // Use setTimeout so the response is delivered asynchronously,
+            // matching the real bridge's behavior.
+            setTimeout(() => {
+                // Dispatch to all listeners currently registered on this bridge
+                // object. We trigger a synthetic MessageEvent-like call by
+                // invoking the listener with the response string directly.
+                // MSAL's BridgeProxy listener accepts both string and {data: string}.
+                const event = { data: responseJson };
+                if (typeof bridge._naaListeners !== "undefined") {
+                    for (const listener of bridge._naaListeners) {
+                        try { listener(event); } catch { /* ignore */ }
+                    }
+                }
+            }, 0);
+        } catch {
+            // If we can't parse the request, nothing we can do
         }
     };
 }

--- a/src/NestedAppAuthBridge.ts
+++ b/src/NestedAppAuthBridge.ts
@@ -1,0 +1,102 @@
+/**
+ * Nested App Authentication (NAA) bridge shim for Azure DevOps extensions.
+ *
+ * This module provides the client-side bridge that connects MSAL's
+ * `createNestablePublicClientApplication` (which expects `window.nestedAppAuthBridge`)
+ * to the Azure DevOps host frame's NAA handler (exposed via XDM as `DevOps.NestedAppAuth`).
+ *
+ * The host-side handler accepts a `processRequest(requestJson)` call and returns
+ * a response JSON string. This shim translates between MSAL's event-based
+ * `postMessage`/`addEventListener` API and the XDM request-response model.
+ */
+
+import { IXDMChannel } from "./XDM";
+
+/**
+ * The interface that the host exposes over XDM under "DevOps.NestedAppAuth".
+ */
+interface INestedAppAuthHost {
+    processRequest(requestJson: string): Promise<string>;
+}
+
+type MessageListener = (response: string | { data: string }) => void;
+
+const nestedAppAuthHostId = "DevOps.NestedAppAuth";
+
+/**
+ * Attempts to initialize the NAA bridge by obtaining a proxy to the host's
+ * NestedAppAuth handler and wiring it to `window.nestedAppAuthBridge`.
+ *
+ * This is called automatically after the SDK handshake completes. If the host
+ * does not expose the NAA endpoint (e.g., feature flag is off), initialization
+ * is silently skipped.
+ *
+ * @param parentChannel - The XDM channel to the host frame
+ */
+export async function initializeNestedAppAuthBridge(parentChannel: IXDMChannel): Promise<void> {
+    try {
+        const hostProxy = await parentChannel.getRemoteObjectProxy<INestedAppAuthHost>(nestedAppAuthHostId);
+        if (!hostProxy || typeof hostProxy.processRequest !== "function") {
+            return;
+        }
+
+        const listeners: MessageListener[] = [];
+
+        (window as any).nestedAppAuthBridge = {
+            addEventListener(type: string, listener: MessageListener): void {
+                if (type === "message") {
+                    listeners.push(listener);
+                }
+            },
+            removeEventListener(type: string, listener: MessageListener): void {
+                if (type === "message") {
+                    const index = listeners.indexOf(listener);
+                    if (index >= 0) {
+                        listeners.splice(index, 1);
+                    }
+                }
+            },
+            postMessage(requestJson: string): void {
+                hostProxy.processRequest(requestJson).then(
+                    (responseJson: string) => {
+                        for (const listener of listeners) {
+                            try {
+                                listener(responseJson);
+                            } catch {
+                                // Listener errors should not break the bridge
+                            }
+                        }
+                    },
+                    (error: any) => {
+                        // If the host call fails, try to extract the requestId
+                        // and send an error response so MSAL doesn't hang.
+                        try {
+                            const request = JSON.parse(requestJson);
+                            const errorResponse = JSON.stringify({
+                                messageType: "NestedAppAuthResponse",
+                                requestId: request.requestId,
+                                success: false,
+                                error: {
+                                    status: "BridgeError",
+                                    code: "XDMError",
+                                    description: error?.message || "An error occurred communicating with the host"
+                                }
+                            });
+                            for (const listener of listeners) {
+                                try {
+                                    listener(errorResponse);
+                                } catch {
+                                    // Ignore listener errors
+                                }
+                            }
+                        } catch {
+                            // If we can't even parse the request, there's nothing we can do
+                        }
+                    }
+                );
+            }
+        };
+    } catch {
+        // Host does not support NAA — silently skip
+    }
+}

--- a/src/NestedAppAuthBridge.ts
+++ b/src/NestedAppAuthBridge.ts
@@ -43,8 +43,7 @@ export async function initializeNestedAppAuthBridge(parentChannel: IXDMChannel):
         ]);
     } catch (err: any) {
         throw new Error(
-            "Nested App Authentication is not available. " +
-            "Ensure the host has NAA support enabled. " +
+            "Nested App Authentication is not available in this Azure DevOps environment yet. " +
             `Details: ${err?.message || err}`
         );
     }
@@ -105,4 +104,12 @@ export async function initializeNestedAppAuthBridge(parentChannel: IXDMChannel):
                 );
             }
         };
+}
+
+/**
+ * Tears down the NAA bridge by removing `window.nestedAppAuthBridge`.
+ * Call this when the extension no longer needs NAA, or during cleanup in tests.
+ */
+export function teardownNestedAppAuthBridge(): void {
+    delete (window as any).nestedAppAuthBridge;
 }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -504,8 +504,7 @@ export async function getAppToken(): Promise<string> {
  * BroadcastChannel issues that block popup-based auth in iframes.
  *
  * Call this after `init()` and before creating an MSAL instance.
- * Requires the extension to declare `entraClientId` in its manifest
- * and the host to have NAA support enabled.
+ * Requires the host to have NAA support enabled.
  *
  * @returns A promise that resolves when the bridge is ready, or rejects
  *          if the host does not support NAA.

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -1,5 +1,5 @@
 import { channelManager } from "./XDM";
-import { initializeNestedAppAuthBridge } from "./NestedAppAuthBridge";
+import { initializeNestedAppAuthBridge, teardownNestedAppAuthBridge } from "./NestedAppAuthBridge";
 
 /**
  * Web SDK version number. Can be specified in an extension's set of demands like: vss-sdk-version/4.2
@@ -521,6 +521,15 @@ export async function getAppToken(): Promise<string> {
 export async function enableNestedAppAuth(): Promise<void> {
     await ready();
     return initializeNestedAppAuthBridge(parentChannel);
+}
+
+/**
+ * Tears down the Nested App Authentication bridge, removing `window.nestedAppAuthBridge`.
+ * Call this when the extension no longer needs NAA support, or during cleanup.
+ * Any in-flight MSAL operations may fail after this call.
+ */
+export function disableNestedAppAuth(): void {
+    teardownNestedAppAuthBridge();
 }
 
 /**

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -1,4 +1,5 @@
 import { channelManager } from "./XDM";
+import { initializeNestedAppAuthBridge } from "./NestedAppAuthBridge";
 
 /**
  * Web SDK version number. Can be specified in an extension's set of demands like: vss-sdk-version/4.2
@@ -337,6 +338,11 @@ export function init(options?: IExtensionInitOptions): Promise<void> {
                     applyTheme(ev.detail.data);
                 });
             }
+
+            // Initialize the Nested App Authentication bridge (non-blocking).
+            // This enables extensions to use MSAL's createNestablePublicClientApplication
+            // for cross-origin authentication via the host frame.
+            initializeNestedAppAuthBridge(parentChannel);
 
             resolveReady();
             resolve();

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -524,9 +524,10 @@ export async function enableNestedAppAuth(): Promise<void> {
 }
 
 /**
- * Tears down the Nested App Authentication bridge, removing `window.nestedAppAuthBridge`.
- * Call this when the extension no longer needs NAA support, or during cleanup.
- * Any in-flight MSAL operations may fail after this call.
+ * Disables the Nested App Authentication bridge. After this call, any MSAL
+ * token requests will receive a `BridgeDisabled` error. The bridge object
+ * remains on `window.nestedAppAuthBridge` so existing MSAL listeners are
+ * not orphaned. Call `enableNestedAppAuth()` to re-enable.
  */
 export function disableNestedAppAuth(): void {
     teardownNestedAppAuthBridge();

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -339,11 +339,6 @@ export function init(options?: IExtensionInitOptions): Promise<void> {
                 });
             }
 
-            // Initialize the Nested App Authentication bridge (non-blocking).
-            // This enables extensions to use MSAL's createNestablePublicClientApplication
-            // for cross-origin authentication via the host frame.
-            initializeNestedAppAuthBridge(parentChannel);
-
             resolveReady();
             resolve();
         });
@@ -498,6 +493,35 @@ export async function getAccessToken(): Promise<string> {
 */
 export async function getAppToken(): Promise<string> {
     return parentChannel.invokeRemoteMethod<{ token: string }>("getAppToken", hostControlId).then((tokenObj) => { return tokenObj.token; });
+}
+
+/**
+ * Enable Nested App Authentication (NAA) for this extension.
+ *
+ * Sets up `window.nestedAppAuthBridge` so that MSAL's
+ * `createNestablePublicClientApplication` can delegate token acquisition
+ * to the Azure DevOps host frame. This avoids cross-origin
+ * BroadcastChannel issues that block popup-based auth in iframes.
+ *
+ * Call this after `init()` and before creating an MSAL instance.
+ * Requires the extension to declare `entraClientId` in its manifest
+ * and the host to have NAA support enabled.
+ *
+ * @returns A promise that resolves when the bridge is ready, or rejects
+ *          if the host does not support NAA.
+ *
+ * @example
+ * ```
+ * await SDK.init();
+ * await SDK.enableNestedAppAuth();
+ * const pca = await createNestablePublicClientApplication({
+ *     auth: { clientId: "your-entra-client-id" }
+ * });
+ * ```
+ */
+export async function enableNestedAppAuth(): Promise<void> {
+    await ready();
+    return initializeNestedAppAuthBridge(parentChannel);
 }
 
 /**

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -4,7 +4,7 @@ import { initializeNestedAppAuthBridge } from "./NestedAppAuthBridge";
 /**
  * Web SDK version number. Can be specified in an extension's set of demands like: vss-sdk-version/4.2
  */
-export const sdkVersion = 4.2;
+export const sdkVersion = 5.0;
 
 const global = window as any;
 if (global._AzureDevOpsSDKVersion) {


### PR DESCRIPTION
## Summary

Adds Nested App Authentication (NAA) support to the Azure DevOps extension SDK, enabling extensions to use MSAL v5's `createNestablePublicClientApplication` for authentication in cross-origin iframes.

## Problem

Extensions running in cross-origin iframes cannot use MSAL v5's BroadcastChannel-based redirect flow due to browser storage partitioning -- the popup and iframe cannot communicate across partitions.

## Solution

The NAA bridge delegates token acquisition to the host frame, where the MSAL PublicClientApplication runs in the top-level browsing context without partitioning issues.

Extensions opt in by calling `SDK.enableNestedAppAuth()` after `SDK.init()`. This sets up `window.nestedAppAuthBridge`, which MSAL's `createNestablePublicClientApplication` discovers automatically.

### How it works

1. Extension calls `SDK.enableNestedAppAuth()` after `SDK.init()`
2. The SDK obtains the `DevOps.NestedAppAuth` remote proxy from the host via XDM
3. It sets `window.nestedAppAuthBridge` with `addEventListener`/`postMessage` (the interface MSAL expects)
4. When MSAL calls `postMessage(requestJson)`, the shim forwards it to the host via XDM
5. The host response is dispatched to registered message listeners

If the host doesn't support NAA, `enableNestedAppAuth()` throws with a clear error message.

### Files changed

- **`src/NestedAppAuthBridge.ts`** (new) -- Bridge shim implementation
- **`src/SDK.ts`** -- Exports `enableNestedAppAuth()` and `disableNestedAppAuth()` functions

### Extension usage

```typescript
import * as SDK from 'azure-devops-extension-sdk';
import { createNestablePublicClientApplication, InteractionRequiredAuthError } from '@azure/msal-browser';

await SDK.init();
await SDK.enableNestedAppAuth();

const pca = await createNestablePublicClientApplication({
    auth: { clientId: 'your-entra-client-id' }
});

try {
    const result = await pca.acquireTokenSilent({
        scopes: ['https://graph.microsoft.com/.default'],
    });
} catch (err) {
    if (err instanceof InteractionRequiredAuthError) {
        const result = await pca.acquireTokenPopup({
            scopes: ['https://graph.microsoft.com/.default'],
        });
    } else {
        throw err;
    }
}
```

### Prerequisites

- Register a SPA app in the Azure Portal with redirect URI: `https://dev.azure.com/_public/_MsalPopup`
- Configure API permissions for the scopes your extension needs
- No changes to the extension manifest are required
